### PR TITLE
Remove not resolving domain hop.kz, or not.

### DIFF
--- a/list
+++ b/list
@@ -235,7 +235,6 @@ hashi.co
 hide.su
 hill.cm
 hit.kg
-hop.kz
 href.li
 ht.ly
 htl.li


### PR DESCRIPTION
Currently not resolving:

```
$ kdig +tls hop.kz @8.8.8.8
;; TLS session (TLS1.3)-(ECDHE-X25519)-(RSA-PSS-RSAE-SHA256)-(AES-256-GCM)
;; ->>HEADER<<- opcode: QUERY; status: NOERROR; id: 47294
;; Flags: qr rd ra; QUERY: 1; ANSWER: 0; AUTHORITY: 1; ADDITIONAL: 1

;; EDNS PSEUDOSECTION:
;; Version: 0; flags: ; UDP size: 512 B; ext-rcode: NOERROR
;; PADDING: 361 B

;; QUESTION SECTION:
;; hop.kz.                      IN      A

;; AUTHORITY SECTION:
hop.kz.                 1800    IN      SOA     ns1.cp.idhost.kz.  asheglov.gmail.com. 1268221912 14400 7200 2419200 3600

;; Received 468 B
;; Time 2022-10-20 01:15:15 CST
;; From 8.8.8.8@853(TCP) in 1055.2 ms
```

The interesting part is, from historical result, it's keep getting similar sitiation every year:

![image](https://user-images.githubusercontent.com/3691490/196760623-1aea18f4-3e68-46c8-99ef-827e5458188b.png)

Maybe try to contact its admin if it's back this time, to see if there's any chance to prevent the same issue happened again.