### PR TITLE
Remove not resolving domain hide.su

### DIFF
--- a/list
+++ b/list
@@ -232,7 +232,6 @@ grhb.me
 haa.su
 han.gl
 hashi.co
-hide.su
 hill.cm
 hit.kg
 href.li


### PR DESCRIPTION
It's dead now.

```
$ kdig +tls A hide.su @8.8.8.8
;; TLS session (TLS1.3)-(ECDHE-X25519)-(RSA-PSS-RSAE-SHA256)-(AES-256-GCM)
;; ->>HEADER<<- opcode: QUERY; status: NXDOMAIN; id: 65376
;; Flags: qr rd ra; QUERY: 1; ANSWER: 0; AUTHORITY: 1; ADDITIONAL: 1

;; EDNS PSEUDOSECTION:
;; Version: 0; flags: ; UDP size: 512 B; ext-rcode: NOERROR
;; PADDING: 367 B

;; QUESTION SECTION:
;; hide.su.            		IN	A

;; AUTHORITY SECTION:
su.                 	1800	IN	SOA	a.dns.ripn.net.  hostmaster.ripn.net. 650193555 86400 14400 2592000 3600

;; Received 468 B
;; Time 2022-10-26 21:10:51 CST
;; From 8.8.8.8@853(TCP) in 228.2 ms
```