### PR TITLE
Remove not resolving domain crum.pl

### DIFF
--- a/list
+++ b/list
@@ -153,7 +153,6 @@ cnn.it
 cockroa.ch
 conta.cc
 cort.as
-crum.pl
 cs.co
 cut.pe
 cute2w.in


### PR DESCRIPTION
```
$ kdig +tls @9.9.9.9 crum.pl
;; TLS session (TLS1.3)-(ECDHE-SECP256R1)-(ECDSA-SECP256R1-SHA256)-(AES-256-GCM)
;; ->>HEADER<<- opcode: QUERY; status: SERVFAIL; id: 48201
;; Flags: qr rd ra ad; QUERY: 1; ANSWER: 0; AUTHORITY: 0; ADDITIONAL: 1

;; EDNS PSEUDOSECTION:
;; Version: 0; flags: ; UDP size: 512 B; ext-rcode: NOERROR

;; QUESTION SECTION:
;; crum.pl.                     IN      A

;; Received 36 B
;; Time 2022-11-04 23:46:20 CST
;; From 9.9.9.9@853(TCP) in 1427.3 ms
```