### PR TITLE
Remove parked domain "fdlr.io"

### DIFF
--- a/list
+++ b/list
@@ -217,7 +217,6 @@ faturl.com
 fav.me
 fave.co
 fb.me
-fdlr.io
 fetnet.tw
 ff.im
 firsturl.de


### PR DESCRIPTION
It seems to be parked at https://www.parkingcrew.com/