### PR TITLE
Move `lnks.fr` to `inactive` list

### DIFF
--- a/inactive
+++ b/inactive
@@ -269,6 +269,7 @@ lnk.in
 lnkd.ly
 lnki.cc
 lnki.nl
+lnks.fr
 lnks.it
 lnkurl.com
 lnky.fr

--- a/list
+++ b/list
@@ -421,7 +421,6 @@ lnk.sk
 lnkd.in
 lnkiy.com
 lnkiy.in
-lnks.fr
 lnnk.in
 loom.ly
 lstu.fr


### PR DESCRIPTION
Similar situation just like #5, blackholed for days and may be back.

No A record:

```
$ kdig +tls A lnks.fr @8.8.8.8
;; TLS session (TLS1.3)-(ECDHE-X25519)-(RSA-PSS-RSAE-SHA256)-(AES-256-GCM)
;; ->>HEADER<<- opcode: QUERY; status: NXDOMAIN; id: 63048
;; Flags: qr rd ra; QUERY: 1; ANSWER: 0; AUTHORITY: 1; ADDITIONAL: 1

;; EDNS PSEUDOSECTION:
;; Version: 0; flags: ; UDP size: 512 B; ext-rcode: NOERROR
;; PADDING: 368 B

;; QUESTION SECTION:
;; lnks.fr.                     IN      A

;; AUTHORITY SECTION:
fr.                     1800    IN      SOA     nsmaster.nic.fr.  hostmaster.nic.fr. 2233188605 3600 1800 3600000 5400

;; Received 468 B
;; Time 2022-12-05 23:04:02 CST
;; From 8.8.8.8@853(TCP) in 45.4 ms
```

No NS record:

```
$ kdig +tls NS lnks.fr @8.8.8.8
;; TLS session (TLS1.3)-(ECDHE-X25519)-(RSA-PSS-RSAE-SHA256)-(AES-256-GCM)
;; ->>HEADER<<- opcode: QUERY; status: NXDOMAIN; id: 49097
;; Flags: qr rd ra; QUERY: 1; ANSWER: 0; AUTHORITY: 1; ADDITIONAL: 1

;; EDNS PSEUDOSECTION:
;; Version: 0; flags: ; UDP size: 512 B; ext-rcode: NOERROR
;; PADDING: 368 B

;; QUESTION SECTION:
;; lnks.fr.                     IN      NS

;; AUTHORITY SECTION:
fr.                     1800    IN      SOA     nsmaster.nic.fr.  hostmaster.nic.fr. 2233188605 3600 1800 3600000 5400

;; Received 468 B
;; Time 2022-12-05 23:04:06 CST
;; From 8.8.8.8@853(TCP) in 45.5 ms
```