### PR TITLE
Add gtly.ink and gtly.to in the list 

### DIFF
--- a/list
+++ b/list
@@ -389,6 +389,8 @@ gq.mn
 gr.pn
 grb.to
 grhb.me
+gtly.ink
+gtly.to
 gtne.ws
 gtnr.it
 haa.su


### PR DESCRIPTION
These domains are utilised by Geo Targetly (geotargetly.com) for geo based URL shorterners.