### PR TITLE
Add small.cat

### DIFF
--- a/list
+++ b/list
@@ -1014,6 +1014,7 @@ skrat.it
 skroc.pl
 skyurl.cc
 slidesha.re
+small.cat
 smart.link
 smarturl.it
 smashed.by


### PR DESCRIPTION
Small.cat is a URL shortener that creates temporary short speakable URLs.

I'm hoping adding it here will remove it from the NextDNS threat intelligence feeds as it I guess it had been flagged for phishing due to registrar notifying me.