### PR TITLE
Add 16 more URL shortener domains

### DIFF
--- a/list
+++ b/list
@@ -616,7 +616,7 @@ ind.pn
 indeedhi.re
 indy.st
 infy.com
-inlink.ru
+inlnk.ru
 insd.io
 insig.ht
 instagr.am

--- a/list
+++ b/list
@@ -20,6 +20,7 @@
 1drv.ms
 1ea.ir
 1kh.de
+1o2.ir
 1shop.io
 1u.fi
 1un.fr
@@ -58,6 +59,7 @@
 69run.fun
 6g6.eu
 7.ly
+707.su
 71a.xyz
 7news.link
 7ny.tv
@@ -311,6 +313,7 @@ ctbc.tw
 ctfl.io
 cultm.ac
 cup.org
+cut.lu
 cut.pe
 cute2w.in
 cutt.ly
@@ -468,6 +471,7 @@ gbod.org
 gbpg.net
 gbte.tech
 gcc.gl
+gclnk.com
 gdurl.com
 gek.link
 gen.cat
@@ -600,6 +604,7 @@ ifix.gd
 ift.tt
 iherb.co
 ihr.fm
+ii1.su
 iii.im
 iiil.io
 il.rog.gg
@@ -611,6 +616,7 @@ ind.pn
 indeedhi.re
 indy.st
 infy.com
+inlink.ru
 insd.io
 insig.ht
 instagr.am
@@ -669,11 +675,13 @@ klck.me
 kli.cx
 klmf.ly
 ko.gl
+kortlink.dk
 kp.org
 kpmg.ch
 krazy.la
 ku.ag
 kuku.lu
+kurl.ru
 kutt.it
 l-i-nk.me
 l.linklyhq.com
@@ -728,6 +736,7 @@ linkshare.pro
 linkye.net
 livemu.sc
 livestre.am
+llk.dk
 llo.to
 lmg.gg
 lmt.co
@@ -846,6 +855,7 @@ nkbp.jp
 nkf.re
 nmrk.re
 nnn.is
+nnna.ru
 nnnna.store
 nokia.ly
 notlong.com
@@ -987,6 +997,7 @@ py.md
 pzdls.co
 q.gs
 qnap.to
+qptr.ru
 qr.ae
 qr.net
 qrco.de
@@ -1157,6 +1168,7 @@ so.arte
 soc.cr
 soch.us
 social.ora.cl
+socx.in
 sokrati.ru
 solsn.se
 sou.nu
@@ -1220,6 +1232,7 @@ ta.co
 tabsoft.co
 taiwangov.com
 tanks.ly
+tapny.su
 tatung.site
 tbb.tw
 tbrd.co
@@ -1326,6 +1339,7 @@ ukoeln.de
 ul.rs
 ul.to
 ul3.ir
+ulvis.net
 ume.la
 umlib.us
 unc.live
@@ -1355,6 +1369,7 @@ urli.ai
 urlify.cn
 urlin.it
 urlink.io
+urlis.net
 urlr.me
 urls.fr
 urls.im
@@ -1487,6 +1502,7 @@ xyvid.tv
 y.ahoo.it
 y2u.be
 yadi.sk
+yal.su
 yelp.to
 yex.tt
 yhoo.it


### PR DESCRIPTION
More actively used URL shorteners found in the wild within the past few weeks.

- 1o2.ir
- 707.su
- cut.lu
- gclnk.com
- ii1.su
- inlnk.ru
- kortlink.dk
- kurl.ru
- llk.dk
- nnna.ru
- qptr.ru
- socx.in
- tapny.su
- ulvis.net
- urlis.net
- yal.su