### PR TITLE
Removing dw.com - false positive

### DIFF
--- a/list
+++ b/list
@@ -373,7 +373,6 @@ dtsx.io
 dub.sh
 dv.gd
 dvrv.ai
-dw.com
 dwz.tax
 dxc.to
 dy.fi


### PR DESCRIPTION
dw.com is a main domain of Deutsche Welle, well-known German news agency

https://en.wikipedia.org/wiki/Deutsche_Welle