### PR TITLE
Add refer.is

### DIFF
--- a/list
+++ b/list
@@ -1044,6 +1044,7 @@ redir.is
 redsto.ne
 redtag.la
 ref.trade.re
+refer.is
 referer.us
 refini.tv
 regmovi.es


### PR DESCRIPTION
This PR adds refer.is into the list of active URL shorteners.

src: https://refer.is/tdafdya6

target: https://github.com/PeterDaveHello/url-shorteners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new domain name, `refer.is`, enhancing the existing list of resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->