### PR TITLE
Adding short.reus.nc

### DIFF
--- a/list
+++ b/list
@@ -1137,6 +1137,7 @@ sho.pe
 shope.ee
 shorl.com
 short.gy
+short.reus.nc
 shorten.asia
 shorturl.ae
 shorturl.asia


### PR DESCRIPTION
Short.reus.nc is a shortener hosted in France, with api available.