### PR TITLE
Add 4 Serbian URL shortener domains ({sn, jz, skr, sk.in}.rs)

### DIFF
--- a/list
+++ b/list
@@ -633,6 +633,7 @@ jnfusa.org
 joo.gl
 jp.rog.gg
 jpeg.ly
+jz.rs
 k-p.li
 kas.pr
 kask.us
@@ -1118,6 +1119,8 @@ siteco.re
 skimmth.is
 skl.sh
 skrat.it
+skr.rs
+sk.in.rs
 skyurl.cc
 slidesha.re
 small.cat
@@ -1135,6 +1138,7 @@ sndn.link
 snip.link
 snip.ly
 snyk.co
+sn.rs
 so.arte
 soc.cr
 soch.us

--- a/list
+++ b/list
@@ -1116,11 +1116,11 @@ sinyi.biz
 sinyi.in
 siriusxm.us
 siteco.re
+sk.in.rs
 skimmth.is
 skl.sh
-skrat.it
 skr.rs
-sk.in.rs
+skrat.it
 skyurl.cc
 slidesha.re
 small.cat
@@ -1133,12 +1133,12 @@ smsng.news
 smsng.us
 smtvj.com
 smu.gs
+sn.rs
 snd.sc
 sndn.link
 snip.link
 snip.ly
 snyk.co
-sn.rs
 so.arte
 soc.cr
 soch.us


### PR DESCRIPTION
## Description
Added the following domains:
- sn.rs
- jz.rs
- skr.rs
- sk.in.rs

## Domain Usage Proof

```
1. https://sn.rs/okgap -> https://google.rs/
2. http://skr.rs/z05L -> https://google.rs/
3. https://jz.rs/defa -> https://google.rs/
4. http://sk.in.rs/QSm -> https://google.rs/
```

## Checklist

- [x] I have confirmed the shortener domain(s) are active/inactive as indicated.
- [x] I have verified that each domain's usage proof is correct and up to date.

## Rationale

Newly found domains used as URL shorteners, for Serbian market.

## Additional Notes

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded supported domains list with four additions: jz.rs, sk.in.rs, skr.rs, and sn.rs.
  * Each new domain is recognized within its existing domain groupings, improving coverage and compatibility when interacting with these addresses.
  * No domains were removed and no other changes were made to existing handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->